### PR TITLE
Enhance study API to generate thesis titles and fetch RRL's

### DIFF
--- a/api/study_api.py
+++ b/api/study_api.py
@@ -1,34 +1,81 @@
 from flask import Flask, jsonify, Blueprint
 import requests
+import random
 from transformers import pipeline
+from tensorflow.keras.backend import clear_session
+from requests.exceptions import RequestException
 
+# Flask Blueprint
 get_study = Blueprint("fetch_result", __name__)
 
-# Load a small but powerful AI model (Flan-T5 Small)
-title_generator = pipeline("text2text-generation", model="google/flan-t5-small")
+# Load the title generator model
+title_generator = pipeline("text2text-generation", model="google/flan-t5-large")
 
 @get_study.route('/api_get', methods=['GET'])
 def fetch_result():
     try:
-        thesis_title = generate_thesis_title()  # Generate a thesis title
+        thesis_title = generate_thesis_title()
+        related_rrls = fetch_related_rrls(thesis_title)
 
-        # Fetch RRLs based on the generated title
-        study_url = f"https://api.semanticscholar.org/graph/v1/paper/search?query={thesis_title}&limit=5"
-        response = requests.get(study_url)
-
-        related_rrls = []
-        if response.status_code == 200:
-            papers = response.json()
-            if "data" in papers:
-                related_rrls = [paper.get("title", "No title found") for paper in papers["data"]]
-
-        return jsonify({"generated_thesis_title": thesis_title, "related_rrls": related_rrls})
+        return jsonify({
+            "generated_thesis_title": thesis_title,
+            "related_rrls": related_rrls
+        })
     
     except Exception as e:
         return jsonify({"message": f"Error: {str(e)}"}), 500
 
 def generate_thesis_title():
-    prompt = f"Create a unique and research-worthy thesis title related to. Avoid repetition."
-    result = title_generator(prompt, max_new_tokens=20, temperature=0.7, top_k=50)  
+    """Generate an academic thesis title using a pre-trained AI model."""
+    try:
+        prompt = (
+            "Generate an academic thesis title for a research study in the field of Information Technology or Computer Science. "
+            "The title should be formal, concise, and research-oriented."
+        )
+
+        clear_session()  # Free up memory before generating the title
+        
+        result = title_generator(
+            prompt, 
+            max_new_tokens=30, 
+            temperature=1.2, 
+            top_k=50, 
+            top_p=0.9, 
+            do_sample=True
+        )  
+
+        return result[0].get('generated_text', 'No title generated').strip()
+
+    except Exception as e:
+        print(f"Error generating thesis title: {e}")
+        return "Title generation failed"
+
+def fetch_related_rrls(thesis_title, per_page=5):
+    url = f"https://api.openalex.org/works?search={thesis_title}&per_page={per_page}"
     
-    return result[0]['generated_text'].strip()
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Raises an error for HTTP issues
+
+        data = response.json()
+        results = data.get("results", [])  # Get results or an empty list if not found
+        
+        related_rrls = []
+        for items in results:
+            title = items.get("title", "No title found")
+            doi = items.get("doi", "No DOI found")
+            openalex_id = items.get("id", "No ID found")
+
+            # Construct source link (prefer DOI, fallback to OpenAlex ID)
+            source_link = f"https://doi.org/{doi}" if doi else openalex_id
+
+            related_rrls.append({
+                "title": title,  # Title comes first
+                "source_link": source_link  # Source link comes second
+            })
+
+        return related_rrls
+
+    except RequestException as e:
+        print(f"Error fetching RRLs: {e}")  # Log errors for debugging
+        return []

--- a/app.py
+++ b/app.py
@@ -1,8 +1,13 @@
 from flask import Flask
+import os
 from api.users_api import api_get
 from api.study_api import get_study
 
 app = Flask(__name__)
+app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
+os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
+
+
 #app.register_blueprint(api_get)
 app.register_blueprint(get_study)
 


### PR DESCRIPTION
This entire **study_api.py* is been optimized by allowing the **fetch_result()** to just call the two important functions which are **thesis_title = generate_thesis_title()** and **related_rrls = fetch_related_rrls(thesis_title)**.

This code is included inside of function **generate_thesis_title()**:

- max_new_tokens=30 → Limit response length (30 tokens).
- temperature=1.2 → Higher value = more randomness.
- top_k=50 → Consider top 50 words for prediction.
- top_p=0.9 → Consider words within 90% probability mass.
- do_sample=True → Enable sampling (instead of deterministic output).

`        
```
result = title_generator(
            prompt, 
            max_new_tokens=30, 
            temperature=1.2, 
            top_k=50, 
            top_p=0.9, 
            do_sample=True
        )  

```
`

This code is included inside of function **fetch_related_rrls()**:

This will return the RRLs that match the generated title and the source of that RRL.
Also, take note inside of this function we're just getting a 5 result since we declared in OpenAlex to return up to 5 RRLs.

`
```
for items in results:
            title = items.get("title", "No title found")
            doi = items.get("doi", "No DOI found")
            openalex_id = items.get("id", "No ID found")

            # Construct source link (prefer DOI, fallback to OpenAlex ID)
            source_link = f"https://doi.org/{doi}" if doi else openalex_id

            related_rrls.append({
                "title": title,  # Title comes first
                "source_link": source_link  # Source link comes second
            })

```
`

**Keywords**: DOI (Digital Object Identifier), OpenAlex API (Works, Results, Search, Per_Page), Prompt