### PR TITLE
Add caching to study API and initialize cache in app

### DIFF
--- a/api/study_api.py
+++ b/api/study_api.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify, Blueprint
 import requests
 import random
 import logging
+from config.cache_config import cache
 from transformers import pipeline
 from tensorflow.keras.backend import clear_session
 from requests.exceptions import RequestException
@@ -20,6 +21,7 @@ get_study = Blueprint("fetch_result", __name__)
 title_generator = pipeline("text2text-generation", model="google/flan-t5-large")
 
 @get_study.route('/api_get', methods=['GET'])
+@cache.cached(timeout=10)  # Cache the result for 30 secs
 def fetch_result():
     try:
         thesis_title = generate_thesis_title()

--- a/app.py
+++ b/app.py
@@ -1,11 +1,13 @@
 from flask import Flask
 import os
+from config.cache_config import cache
 from api.users_api import api_get
 from api.study_api import get_study
 
 app = Flask(__name__)
 app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
 os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
+cache.init_app(app)
 
 
 #app.register_blueprint(api_get)

--- a/config/cache_config.py
+++ b/config/cache_config.py
@@ -1,0 +1,3 @@
+from flask_caching import Cache
+
+cache = Cache(config={'CACHE_TYPE': 'SimpleCache', 'CACHE_DEFAULT_TIMEOUT': 300})


### PR DESCRIPTION
```
from flask_caching import Cache

cache = Cache(config={'CACHE_TYPE': 'SimpleCache', 'CACHE_DEFAULT_TIMEOUT': 300})

```

**'CACHE_TYPE': 'SimpleCache'**

CACHE_TYPE tells Flask what kind of caching to use.
'SimpleCache' means it stores data in memory (RAM) but does not persist it after the app stops.
It’s fast, but if the app restarts, the cache is lost.

**'CACHE_DEFAULT_TIMEOUT': 300**

This means cache expires after 300 seconds (5 minutes).
After 5 minutes, the data is removed from the cache, and the API will fetch fresh data.
